### PR TITLE
chore: fix Containerfile and compiling

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,9 +1,8 @@
 FROM scratch as builder
-COPY packages/backend/dist/ /extension/dist
-COPY packages/backend/package.json /extension/
-COPY packages/backend/media/ /extension/media
+COPY dist/ /extension/dist
+COPY package.json /extension/
 COPY LICENSE /extension/
-COPY packages/backend/icon.png /extension/
+COPY icon.png /extension/
 COPY README.md /extension/
 
 FROM scratch

--- a/README.md
+++ b/README.md
@@ -79,18 +79,24 @@ More information on how to package and publish your extension can be found in ou
 
 However, we have provided a pre-made Containerfile in this template for you to try.
 
-1. Package your extension by building the image:
+1. Ensure that you have built your project:
+
+```sh
+$ npm run build
+```
+
+2. Package your extension by building the image:
 
 ```sh
 $ podman build -t quay.io/myusername/myextension .
 ```
 
-2. Push the extension to an external registry:
+3. Push the extension to an external registry:
 
 ```sh
 $ podman push quay.io/myusername/myextension
 ```
 
-3. Install via the Podman Desktop "Install Custom..." button:
+4. Install via the Podman Desktop "Install Custom..." button:
 
 ![custom install](/images/custom_install.png)

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "version": "0.0.1",
   "icon": "icon.png",
   "publisher": "you",
+  "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "podman-desktop": ">=1.10.0"
+    "podman-desktop": ">=1.12.0"
   },
-  "main": "./dist/extension.js",
+  "main": "dist/extension.js",
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,3 @@
-import type { ExtensionContext } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 
 /**
@@ -7,7 +6,7 @@ import * as extensionApi from '@podman-desktop/api';
  */
 
 // Initialize the activation of the extension.
-export async function activate(extensionContext: ExtensionContext): Promise<void> {
+export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
   console.log('starting hello world extension');
 
   // Create a dialog that says "Hello World" with the extensionApi on load

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,24 +1,17 @@
 {
   "compilerOptions": {
-    "strict":true,
-    "target": "esnext",
-    "module": "esnext",
+    "target": "ES2020",
+    "module": "CommonJS", // Since we are not using vite, we need to use CommonJS for Podman Desktop
     "moduleResolution": "Node",
     "resolveJsonModule": true,
-    "lib": [
-      "ES2017",
-      "webworker",
-      "dom",
-    ],
+    "lib": ["ES2020", "webworker"],
     "sourceMap": true,
+    "rootDir": "src",
     "outDir": "dist",
-    "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
-    "types": [
-      "node",
-    ],
+    "types": ["node"],
+    "strictNullChecks": true,
+    "allowSyntheticDefaultImports": true
   },
-  "include": [
-    "src",
-  ],
+  "include": ["src"]
 }


### PR DESCRIPTION
chore: fix Containerfile and compiling

Fixes:
* Containerfile not building correctly
* tsconfig not setup correctly to properly build with module support, so
  it was not building correctly.
* extension.ts file not needed an extra import line

Closes: https://github.com/podman-desktop/extension-template-minimal/issues/4

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
