### PR TITLE
chore: add package manager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,6 @@
     "@podman-desktop/api": "1.12.0",
     "@types/node": "^20",
     "typescript": "5.5.4"
-  }
+  },
+  "packageManager": "npm@11.0.0+sha512.11dff29565d2297c74e7c594a9762581bde969f0aa5cbe6f5b3644bf008a16c065ece61094d9ffbb81125be38df8e1ba43eb8244b3d30c61eb797e9a2440e3ec"
 }


### PR DESCRIPTION
add package manager field to run the expected package manager by default