### PR TITLE
chore: add AI-ready guidance and skills scaffolding

### DIFF
--- a/.agentready-config.yaml
+++ b/.agentready-config.yaml
@@ -1,0 +1,9 @@
+excluded_attributes:
+ - openapi_specs
+ - container_setup
+ - dbt_project_config
+ - dbt_model_documentation
+ - dbt_data_tests
+ - dbt_project_structure
+ - architecture_decisions
+ - repomix_config

--- a/.agents/rules/project.md
+++ b/.agents/rules/project.md
@@ -1,0 +1,10 @@
+## Scope
+
+Applies to all files in this repository.
+
+## Rules
+
+- Keep extension entrypoint logic in `src/extension.ts`.
+- Register commands/menus/configuration in `package.json` `contributes`.
+- Use `@podman-desktop/api` for Podman Desktop integration points.
+- Keep startup logic fast and avoid blocking activation.

--- a/.agents/skills/extension-development/SKILL.md
+++ b/.agents/skills/extension-development/SKILL.md
@@ -1,0 +1,22 @@
+# Extension Development
+
+Use this guide when adding or changing extension behavior.
+
+## Core flow
+
+1. Declare user-facing integration in `package.json` under `contributes`.
+2. Implement behavior in `src/extension.ts`.
+3. Keep commands small and delegate reusable logic to helper functions.
+
+## Common tasks
+
+- Add command: `contributes.commands` + API command registration.
+- Add menu action: `contributes.menus` entry that invokes a command.
+- Add settings: `contributes.configuration` and read with extension API.
+
+## Validation
+
+```sh
+npm run build
+npx tsc --noEmit src/extension.ts
+```

--- a/.agents/skills/unit-testing/SKILL.md
+++ b/.agents/skills/unit-testing/SKILL.md
@@ -1,0 +1,17 @@
+# Unit Testing
+
+Use this guide when adding tests to the minimal template.
+
+## Recommendation
+
+- Use Vitest for unit tests.
+- Mock `@podman-desktop/api` behavior at module boundaries.
+- Focus tests on command handlers and side effects (notifications, config use).
+
+## Suggested setup
+
+If tests are introduced, add:
+
+- `vitest` and `@types/node` dev dependencies as needed
+- `npm test` script
+- `*.spec.ts` files colocated with tested logic

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+ "hooks": {
+  "PostToolUse": [
+   {
+    "matcher": "Edit|Write",
+    "hooks": [
+     {
+      "type": "command",
+      "command": "npx prettier --write \"$CLAUDE_FILE_PATH\" 2>/dev/null; exit 0"
+     }
+    ]
+   }
+  ],
+  "PreToolUse": [
+   {
+    "matcher": "Bash",
+    "hooks": [
+     {
+      "type": "command",
+      "command": "echo \"$CLAUDE_TOOL_INPUT\" | grep -qE '(rm -rf|git push --force|git reset --hard|git checkout \\.)' && echo 'BLOCK: Destructive operation detected. Please confirm with the user first.' && exit 1 || exit 0"
+     }
+    ]
+   }
+  ]
+ }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .eslintcache
 **/coverage
 media
+.agentready

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md
+
+## Project Overview
+
+Minimal Podman Desktop extension template with a single TypeScript entrypoint.
+It is intended as the smallest starting point for command/menu contributions and
+simple extension lifecycle logic.
+
+- **Tech stack**: TypeScript, Node.js, npm
+- **Extension API**: `@podman-desktop/api`
+- **Main entrypoint**: `src/extension.ts`
+
+## Quick Start
+
+```sh
+npm install
+npm run build
+```
+
+## Essential Commands
+
+```sh
+npm run build   # compile TypeScript into dist/
+npm run watch   # incremental TypeScript rebuild
+```
+
+## Single-File Verification
+
+```sh
+npx eslint path/to/file.ts
+npx tsc --noEmit path/to/file.ts
+```
+
+## Skills
+
+Task-specific guidance lives in `.agents/skills/`:
+
+- `extension-development` - adding commands, menus, and API usage
+- `unit-testing` - lightweight Vitest testing patterns
+
+## Architecture
+
+- `src/extension.ts` registers extension logic and Podman Desktop API calls.
+- `package.json` `contributes` section defines commands/menus/views.
+- Built output is `dist/extension.js` loaded by Podman Desktop.
+
+## Pattern References
+
+- Add a command: `package.json` `contributes.commands` + handler in `src/extension.ts`
+- Add menu item: `package.json` `contributes.menus` + command implementation
+- Add config key: `package.json` `contributes.configuration`


### PR DESCRIPTION
## What does this PR do?

Adds baseline AI-readiness files to the minimal template so generated extensions include agent guidance and safer automation defaults:

- Add `AGENTS.md` with project overview, commands, and patterns
- Add `.agentready-config.yaml` exclusions suited for this template
- Add `.claude/settings.json` with safe pre-tool guard + post-edit formatting hook
- Add starter `.agents/rules/` and `.agents/skills/` docs
- Update `.gitignore` to ignore `.agentready`

## What issues does this PR fix or reference?

Refs podman-desktop/podman-desktop#17640

## How to test this PR?

1. Clone this branch and inspect added AI-readiness files.
2. Verify the new docs are template-agnostic and align with minimal structure.
3. Confirm `.agentready` is ignored via `.gitignore`.


Made with [Cursor](https://cursor.com)